### PR TITLE
fix: tab crash (pool exhaustion) + AudioContext recovery

### DIFF
--- a/src/utils/effectChains.test.js
+++ b/src/utils/effectChains.test.js
@@ -212,51 +212,50 @@ describe('effectChains', () => {
 
   // ── Effect chain pool ──────────────────────────────────────────────────────
   describe('pool', () => {
-    it('starts with 8 available chains', () => {
+    it('starts with 32 available chains', () => {
       freshPool()
-      expect(getEffectChainStats().available).toBe(8)
+      expect(getEffectChainStats().available).toBe(32)
     })
 
     it('getChain() returns a chain and updates available/active counts', () => {
       const pool = freshPool()
       const chain = pool.getChain()
       expect(chain).not.toBeNull()
-      expect(getEffectChainStats().available).toBe(7)
+      expect(getEffectChainStats().available).toBe(31)
       expect(getEffectChainStats().active).toBe(1)
     })
 
-    it('pool overflow: 9th getChain() warns and still returns a usable chain', () => {
+    it('pool overflow: getChain() returns null when all chains are active', () => {
       const pool = freshPool()
-      const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const chains = Array.from({ length: 9 }, () => pool.getChain())
-
-      expect(spy).toHaveBeenCalledWith('Effect chain pool exhausted, creating new chain')
-      expect(chains[8]).not.toBeNull()
-      expect(getEffectChainStats().active).toBe(9)
+      // Exhaust the pool (32 chains)
+      const chains = Array.from({ length: 32 }, () => pool.getChain())
       expect(getEffectChainStats().available).toBe(0)
+      expect(getEffectChainStats().active).toBe(32)
 
-      spy.mockRestore()
+      // 33rd request must return null — no overflow chain created
+      const overflow = pool.getChain()
+      expect(overflow).toBeNull()
+      expect(getEffectChainStats().active).toBe(32) // count unchanged
+
       chains.forEach((c) => pool.releaseChain(c))
     })
 
-    it('overflow chain is cleaned up on release (pool does not grow past cap)', () => {
+    it('pool recovers after notes finish (all chains returned, none leaked)', () => {
       const pool = freshPool()
-      vi.spyOn(console, 'warn').mockImplementation(() => {})
-      const chains = Array.from({ length: 9 }, () => pool.getChain())
+      const chains = Array.from({ length: 32 }, () => pool.getChain())
       chains.forEach((c) => pool.releaseChain(c))
-      vi.restoreAllMocks()
 
       const stats = getEffectChainStats()
-      expect(stats.available).toBe(8)
+      expect(stats.available).toBe(32)
       expect(stats.active).toBe(0)
-      expect(stats.total).toBe(8)
+      expect(stats.total).toBe(32)
     })
 
     it('releaseChain is safe for chains not tracked by the pool', () => {
       const pool = freshPool()
       expect(() => pool.releaseChain({})).not.toThrow()
       expect(() => pool.releaseChain(null)).not.toThrow()
-      expect(getEffectChainStats().available).toBe(8)
+      expect(getEffectChainStats().available).toBe(32)
     })
   })
 })

--- a/src/utils/effectChains.ts
+++ b/src/utils/effectChains.ts
@@ -359,7 +359,7 @@ class EffectChainPool {
   private availableChains: EffectChain[]
   private activeChains: Set<EffectChain>
 
-  constructor(audioContext: AudioContext, poolSize = 8) {
+  constructor(audioContext: AudioContext, poolSize = 32) {
     this.audioContext = audioContext
     this.poolSize = poolSize
     this.availableChains = []
@@ -373,11 +373,12 @@ class EffectChainPool {
     }
   }
 
-  getChain(): EffectChain {
-    let chain = this.availableChains.pop()
+  getChain(): EffectChain | null {
+    const chain = this.availableChains.pop()
     if (!chain) {
-      console.warn('Effect chain pool exhausted, creating new chain')
-      chain = new EffectChain(this.audioContext, 'overflow')
+      // Pool exhausted — return null so callers drop the note rather than
+      // creating unbounded overflow chains that accumulate and crash the tab.
+      return null
     }
     chain.activate()
     this.activeChains.add(chain)

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -302,28 +302,8 @@ const createOptimizedBeep = (frequency: number, duration = 0.15, volume = 0.3, p
   const effectChain = chainPool.getChain();
 
   if (!effectChain) {
-    console.warn('No effect chain available, falling back to basic sound');
-    const gainNode = pool.getNode('gain') as GainNode | null;
-    const panNode = pool.getNode('stereoPanner') as StereoPannerNode | null;
-    if (!gainNode || !panNode) return;
-
-    oscillator.connect(gainNode);
-    gainNode.connect(panNode);
-    panNode.connect(globalCompressor || ctx.destination);
-
-    const currentTime = ctx.currentTime;
-    gainNode.gain.setValueAtTime(0, currentTime);
-    gainNode.gain.linearRampToValueAtTime(volume, currentTime + 0.01);
-    gainNode.gain.linearRampToValueAtTime(0, currentTime + duration);
-    panNode.pan.setValueAtTime(Math.max(-1, Math.min(1, pan)), currentTime);
-
-    oscillator.start(currentTime);
-    oscillator.stop(currentTime + duration);
-    oscillator.onended = () => {
-      pool.releaseNode(gainNode, 'gain');
-      pool.releaseNode(panNode, 'stereoPanner');
-    };
-
+    // Pool exhausted — drop this note. Creating overflow chains or flooding
+    // the audioPool both cause unbounded node accumulation and tab crashes.
     return;
   }
 
@@ -358,9 +338,11 @@ const createOptimizedBeep = (frequency: number, duration = 0.15, volume = 0.3, p
 
   // Sample-accurate cleanup tied to oscillator end (covers reverb/delay tails).
   // Using onended avoids wall-clock setTimeout drift and orphan timers on unmount.
-  const reverbTailTime = reverb.enabled ? 2.0 : 0;
+  // Reverb tail is derived from actual IR duration (0.3 + roomSize*2.2) rather
+  // than a fixed 2 s so chains return to the pool sooner, reducing peak demand.
+  const reverbTailTime = reverb.enabled ? (0.3 + reverb.roomSize * 2.2) : 0;
   const delayTailTime = delay.enabled ? delay.time * 4 : 0;
-  const tailTime = Math.max(reverbTailTime, delayTailTime);
+  const tailTime = Math.min(3.0, Math.max(reverbTailTime, delayTailTime));
   oscillator.stop(currentTime + duration + tailTime);
   oscillator.onended = () => {
     chainPool.releaseChain(effectChain);

--- a/src/utils/sound.ts
+++ b/src/utils/sound.ts
@@ -93,6 +93,14 @@ export const initAudioContext = () => {
     // Initialize audio pools for memory optimization
     getAudioPool(audioContext);
     getEffectChainPool(audioContext);
+
+    // Recover automatically from transient hardware/renderer errors (e.g. audio
+    // device switch, system sleep, "AudioContext encountered an error" events).
+    audioContext.onstatechange = () => {
+      if (audioContext && (audioContext.state === 'suspended' || audioContext.state === 'interrupted' as AudioContextState)) {
+        audioContext.resume().catch(() => { /* best-effort */ })
+      }
+    }
   }
   return audioContext;
 };
@@ -290,7 +298,6 @@ const createOptimizedBeep = (frequency: number, duration = 0.15, volume = 0.3, p
   const ctx = audioContext
   if (!ctx) return
 
-  const pool = getAudioPool(ctx);
   const chainPool = getEffectChainPool(ctx);
   const oscillator = ctx.createOscillator();
 


### PR DESCRIPTION
## What's in this PR

Bug fixes for the deployed app at https://circlegetsquare.github.io/oscillaphone/.

---

### fix: tab crash from effect chain pool exhaustion

**Root cause:** When many balls were colliding rapidly, `getChain()` created unbounded overflow `EffectChain` objects (each with ~18 AudioNodes) whenever the pool of 8 was exhausted. With 50 balls, this happened on every frame — thousands of nodes accumulated until the browser tab ran out of memory and crashed.

**Symptom:** Console flooded with "Effect chain pool exhausted, creating new chain"; app eventually crashed.

**Changes:**
- `effectChains.ts`: `getChain()` now returns `null` when the pool is exhausted — no overflow chains ever created. Pool size raised 8 → 32 to handle normal burst load.
- `sound.ts`: `null` effectChain silently drops the note. Reverb tail time is now derived from the actual IR duration (`0.3 + roomSize×2.2`) rather than a fixed 2.0 s, so chains return to the pool sooner. Tail capped at 3.0 s. Removed now-unused `pool` variable.
- `effectChains.test.js`: updated pool size assertions (8→32), replaced overflow-creates-chain tests with overflow-returns-null tests.

---

### fix: recover AudioContext from transient renderer/hardware errors

**Symptom:** Intermittent "AudioContext encountered an error from the audio device or the WebAudio renderer" in the console. App continued running but could silently go silent if the context was left suspended.

**Change:** Added `onstatechange` handler on the `AudioContext` that calls `resume()` whenever the context enters `suspended` or `interrupted` state. Handles audio device switches, system sleep/wake, and browser audio thread hiccups automatically without requiring a user gesture.

---

### Baseline
`tsc --noEmit` clean · `npm run lint` 0 errors / 3 known warnings · `npm test` 62/62
